### PR TITLE
Updates `cert` to work with newer versions of openssl

### DIFF
--- a/tools/bin/cert
+++ b/tools/bin/cert
@@ -101,7 +101,7 @@ fi
 #  \1:           print just the part we grabbed with the ()
 #        
 getCN() {
-	  echo $1 | sed -E 's+^.*CN\s*=\s*([^/,]*).*+\1+'
+    echo $1 | sed -E 's+^.*CN\s*=\s*([^/,]*).*+\1+'
 }
 
 #	print the common name
@@ -110,7 +110,7 @@ getCN() {
 # 
 if [ $common ]
 then
-		getCN "`openssl x509 -noout -subject -in "${cert_name}"`"
+    getCN "`openssl x509 -noout -subject -in "${cert_name}"`"
 fi
 
 #	print the serial number
@@ -124,7 +124,7 @@ fi
 #
 if [ $issuer ]
 then
-		getCN "`openssl x509 -noout -issuer -in "${cert_name}"`"
+    getCN "`openssl x509 -noout -issuer -in "${cert_name}"`"
 fi
 
 #	print the issuer hash

--- a/tools/bin/cert
+++ b/tools/bin/cert
@@ -89,11 +89,28 @@ then
     cert=true
 fi
 
+# function to grab the CN from output of different versions of openssl
+# format 1: "subject=C = xx, CN = commonname, emailAddress = xx"
+# format 2: "subject= /C=xx/CN=commonname/emailAddress=xx"
+#
+# regex: 
+#  ^.*CN\s*=\s*: starting from the beginning up to "CN" and 
+#                optional space around the "=",
+#  ([^/,]):      grab text that isn't a slash or a comma
+#  .*:           eat the rest to the end of the text
+#  \1:           print just the part we grabbed with the ()
+#        
+getCN() {
+	  echo $1 | sed -E 's+^.*CN\s*=\s*([^/,]*).*+\1+'
+}
+
 #	print the common name
 #
+# sed pattern: grab the contents after CN= for formats returned in different versions of openssl
+# 
 if [ $common ]
 then
-    openssl x509 -noout -subject -in "${cert_name}" | sed -r 's+^.*CN\s*=\s*([^/,]*).*+\1+'
+		getCN "`openssl x509 -noout -subject -in "${cert_name}"`"
 fi
 
 #	print the serial number
@@ -107,7 +124,7 @@ fi
 #
 if [ $issuer ]
 then
-    openssl x509 -noout -issuer -in "${cert_name}" | sed -r 's+^.*CN\s*=\s*([^/,]*).*+\1+'
+		getCN "`openssl x509 -noout -issuer -in "${cert_name}"`"
 fi
 
 #	print the issuer hash

--- a/tools/bin/cert
+++ b/tools/bin/cert
@@ -93,7 +93,7 @@ fi
 #
 if [ $common ]
 then
-    openssl x509 -noout -subject -in "${cert_name}" | sed 's/^.*CN=//' | sed 's/\/.*//'
+    openssl x509 -noout -subject -in "${cert_name}" | sed -r 's+^.*CN\s*=\s*([^/,]*).*+\1+'
 fi
 
 #	print the serial number
@@ -107,7 +107,7 @@ fi
 #
 if [ $issuer ]
 then
-    openssl x509 -noout -issuer -in "${cert_name}" | sed 's/^.*CN=//' | sed 's/\/.*//'
+    openssl x509 -noout -issuer -in "${cert_name}" | sed -r 's+^.*CN\s*=\s*([^/,]*).*+\1+'
 fi
 
 #	print the issuer hash


### PR DESCRIPTION
The `sed` patterns broke with newer versions of openssl when extracting the common name of a certificate.